### PR TITLE
Add stats section to demo-premium-lodge index page

### DIFF
--- a/demo-premium-lodge/css/style.css
+++ b/demo-premium-lodge/css/style.css
@@ -449,6 +449,58 @@ h3 { font-size: clamp(1.4rem, 2.5vw, 2rem); }
   z-index: -1;
 }
 
+/* === STATS SECTION === */
+.stats {
+  padding: var(--space-xl) var(--space-md);
+  background: var(--color-surface);
+}
+
+.stats-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.stat-number {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 5vw, 4.5rem);
+  font-weight: 600;
+  color: var(--color-gold);
+  line-height: 1;
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.01em;
+}
+
+.stat-label {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+@media (max-width: 768px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 /* === BEATS SECTION === */
 .beats {
   padding: var(--space-xl) var(--space-md);

--- a/demo-premium-lodge/index.html
+++ b/demo-premium-lodge/index.html
@@ -108,6 +108,34 @@
     </section>
 
 
+    <!-- === STATS SECTION === -->
+    <section id="stats" class="stats" aria-label="Statistikk">
+      <div class="stats-inner">
+        <div class="section-header fade-in">
+          <span class="section-badge" data-i18n="stats.badge">Orkla Laksegård i tall</span>
+        </div>
+        <div class="stats-grid">
+          <div class="stat-item fade-in">
+            <span class="stat-number" data-count-target="75" data-count-suffix="+">75+</span>
+            <span class="stat-label" data-i18n="stats.label1">År med fisketradisjon</span>
+          </div>
+          <div class="stat-item fade-in fade-in-delay-1">
+            <span class="stat-number" data-count-target="2600" data-count-display="2 600">2 600</span>
+            <span class="stat-label" data-i18n="stats.label2">Meter elvestrekk</span>
+          </div>
+          <div class="stat-item fade-in fade-in-delay-2">
+            <span class="stat-number" data-count-target="350" data-count-suffix="+">350+</span>
+            <span class="stat-label" data-i18n="stats.label3">Laks fanget per sesong</span>
+          </div>
+          <div class="stat-item fade-in fade-in-delay-3">
+            <span class="stat-number" data-count-target="9">9</span>
+            <span class="stat-label" data-i18n="stats.label4">Maks stenger samtidig</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+
     <!-- === BEATS SECTION === -->
     <section id="beats" class="beats" aria-label="Våre beats">
       <div class="beats-inner">

--- a/demo-premium-lodge/js/main.js
+++ b/demo-premium-lodge/js/main.js
@@ -148,6 +148,13 @@ const translations = {
     'priceref.label.early': 'Tidligsesong',
     'priceref.label.peak': 'Høysesong',
     'priceref.label.late': 'Sluttsesong',
+
+    // Stats section
+    'stats.badge': 'Orkla Laksegård i tall',
+    'stats.label1': 'År med fisketradisjon',
+    'stats.label2': 'Meter elvestrekk',
+    'stats.label3': 'Laks fanget per sesong',
+    'stats.label4': 'Maks stenger samtidig',
   },
 
   en: {
@@ -298,6 +305,13 @@ const translations = {
     'priceref.label.early': 'Early season',
     'priceref.label.peak': 'Peak season',
     'priceref.label.late': 'Late season',
+
+    // Stats section
+    'stats.badge': 'Orkla Salmon Lodge in numbers',
+    'stats.label1': 'Years of fishing tradition',
+    'stats.label2': 'Metres of river stretch',
+    'stats.label3': 'Salmon caught per season',
+    'stats.label4': 'Max rods at any time',
   }
 };
 
@@ -724,6 +738,46 @@ function initBeatFromURL() {
   }
 }
 
+// === STATS COUNT-UP ===
+function initStatsCounter() {
+  const numbers = document.querySelectorAll('.stat-number[data-count-target]');
+  if (!numbers.length) return;
+
+  const easeOutCubic = t => 1 - Math.pow(1 - t, 3);
+  const duration = 2000;
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (!entry.isIntersecting) return;
+      observer.unobserve(entry.target);
+
+      const el = entry.target;
+      const target = parseInt(el.dataset.countTarget, 10);
+      const suffix = el.dataset.countSuffix || '';
+      const displayFinal = el.dataset.countDisplay || null;
+      const start = performance.now();
+
+      function tick(now) {
+        const elapsed = now - start;
+        const progress = Math.min(elapsed / duration, 1);
+        const eased = easeOutCubic(progress);
+        const current = Math.round(eased * target);
+
+        if (progress < 1) {
+          el.textContent = current + suffix;
+          requestAnimationFrame(tick);
+        } else {
+          el.textContent = displayFinal ? displayFinal + suffix : target + suffix;
+        }
+      }
+
+      requestAnimationFrame(tick);
+    });
+  }, { threshold: 0.4 });
+
+  numbers.forEach(el => observer.observe(el));
+}
+
 // === INIT ===
 document.addEventListener('DOMContentLoaded', () => {
   initLanguage();
@@ -734,4 +788,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initModal();
   initBeatBookLinks();
   initBeatFromURL();
+  initStatsCounter();
 });


### PR DESCRIPTION
- 4 animated counters: 75+, 2600, 350+, 9
- Count-up animation via IntersectionObserver, easeOutCubic over 2s
- Full-width dark background, 4-col desktop / 2-col mobile grid
- NO/EN translations wired via data-i18n
Close #3 