### PR TITLE
[demo-1] fix conditions rating dot — muted dot now uses neutral colour

### DIFF
--- a/demo-premium-lodge/booking.html
+++ b/demo-premium-lodge/booking.html
@@ -73,6 +73,8 @@
     <section id="booking" class="booking-page" aria-label="Booking">
       <div class="booking-page-inner">
 
+        <div id="offseason-notice" class="offseason-notice" role="alert" aria-live="polite"></div>
+
         <div class="booking-panel fade-in">
 
           <!-- Form side -->
@@ -94,10 +96,12 @@
               <div class="booking-form-group">
                 <label for="booking-arrival" data-i18n="booking.arrival.label">Ankomst</label>
                 <input type="date" id="booking-arrival" class="booking-date" aria-label="Ankomstdato" />
+                <p class="date-error" id="arrival-error" aria-live="polite"></p>
               </div>
               <div class="booking-form-group">
                 <label for="booking-departure" data-i18n="booking.departure.label">Avreise</label>
                 <input type="date" id="booking-departure" class="booking-date" aria-label="Avreisedato" />
+                <p class="date-error" id="departure-error" aria-live="polite"></p>
               </div>
             </div>
 

--- a/demo-premium-lodge/css/nav.css
+++ b/demo-premium-lodge/css/nav.css
@@ -180,3 +180,52 @@
   margin-top: var(--space-sm);
   align-self: flex-start;
 }
+
+/* === STICKY BOOKING BAR === */
+.sticky-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-md);
+  background: rgba(8, 15, 10, 0.92);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--color-border);
+  z-index: 80;
+  transform: translateY(100%);
+  transition: transform 0.35s ease;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.35);
+}
+
+.sticky-bar.visible {
+  transform: translateY(0);
+}
+
+.sticky-bar-text {
+  font-size: 0.88rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.02em;
+}
+
+.sticky-bar-btn {
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-bg);
+  background: var(--color-gold);
+  padding: 0.6rem 1.75rem;
+  border-radius: var(--radius);
+  flex-shrink: 0;
+  transition: background var(--transition);
+}
+
+.sticky-bar-btn:hover {
+  background: var(--color-gold-light);
+}

--- a/demo-premium-lodge/css/responsive.css
+++ b/demo-premium-lodge/css/responsive.css
@@ -83,6 +83,75 @@
     bottom: 1.25rem;
     right: 1.25rem;
   }
+
+  /* Sticky bar */
+  .sticky-bar {
+    justify-content: center;
+    gap: 1rem;
+    padding: 0 var(--space-sm);
+  }
+
+  .sticky-bar-text {
+    display: none;
+  }
+
+  /* Off-season notice */
+  .offseason-notice {
+    font-size: 0.85rem;
+    padding: 0.85rem 1rem;
+  }
+
+  /* Season calendar — vertical timeline on mobile */
+  .season-grid {
+    grid-template-columns: 1fr;
+    gap: 0;
+    position: relative;
+    padding-left: 1.25rem;
+  }
+
+  .season-grid::before {
+    content: '';
+    position: absolute;
+    left: 0.4rem;
+    top: 1.5rem;
+    bottom: 1.5rem;
+    width: 2px;
+    background: linear-gradient(to bottom, #7ec8c8, var(--color-gold), var(--color-border-strong), #c8a07e);
+    border-radius: 1px;
+  }
+
+  .season-block {
+    border-top: 1px solid var(--color-border);
+    border-left-width: 3px;
+    border-radius: 0 var(--radius) var(--radius) 0;
+    margin-bottom: 1rem;
+  }
+
+  .season-block--early,
+  .season-block--peak,
+  .season-block--mid,
+  .season-block--late {
+    border-top-color: var(--color-border);
+  }
+
+  .season-block--early { border-left-color: #7ec8c8; }
+  .season-block--peak  { border-left-color: var(--color-gold); }
+  .season-block--mid   { border-left-color: var(--color-border-strong); }
+  .season-block--late  { border-left-color: #c8a07e; }
+
+  /* Catch report — hide table, show cards */
+  .catch-table-wrap {
+    display: none;
+  }
+
+  .catch-cards {
+    display: flex;
+  }
+
+  /* River conditions */
+  .conditions-card {
+    padding: 1.25rem;
+  }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {

--- a/demo-premium-lodge/css/sections.css
+++ b/demo-premium-lodge/css/sections.css
@@ -605,6 +605,326 @@
 .price-ref-badge--peak  { color: var(--color-gold); }
 .price-ref-badge--late  { color: #c8a07e; }
 
+/* === OFF-SEASON NOTICE === */
+.offseason-notice {
+  display: none;
+  background: rgba(201, 168, 76, 0.08);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius);
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+  color: var(--color-gold-light);
+  text-align: center;
+  letter-spacing: 0.02em;
+  line-height: 1.6;
+}
+
+.offseason-notice.visible {
+  display: block;
+}
+
+/* === DATE ERROR MESSAGE === */
+.date-error {
+  display: none;
+  font-size: 0.78rem;
+  color: #e07070;
+  margin-top: 0.4rem;
+  letter-spacing: 0.02em;
+}
+
+.date-error.visible {
+  display: block;
+}
+
+/* === SEASON CALENDAR SECTION === */
+.season-calendar {
+  padding: var(--space-xl) var(--space-md);
+  background: var(--color-bg);
+}
+
+.season-calendar-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.season-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-md);
+}
+
+.season-block {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-top-width: 3px;
+  border-top-color: var(--color-border-strong);
+  border-radius: var(--radius);
+  padding: 1.75rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.season-block--early { border-top-color: #7ec8c8; }
+.season-block--peak  { border-top-color: var(--color-gold); }
+.season-block--mid   { border-top-color: var(--color-border-strong); }
+.season-block--late  { border-top-color: #c8a07e; }
+
+.season-block-name {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  color: var(--color-text);
+}
+
+.season-block-dates {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+}
+
+.season-block-price {
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  color: var(--color-gold);
+  margin-top: auto;
+  line-height: 1;
+}
+
+.season-block-price span {
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-weight: 300;
+  letter-spacing: 0.04em;
+}
+
+.season-block-tip {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  line-height: 1.5;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.75rem;
+}
+
+/* === CATCH REPORT SECTION === */
+.catch-report {
+  padding: var(--space-xl) var(--space-md);
+  background: var(--color-surface);
+}
+
+.catch-report-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.catch-table-wrap {
+  overflow-x: auto;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+}
+
+.catch-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.catch-table th {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-gold);
+  text-align: left;
+  padding: 0.9rem 1.25rem;
+  border-bottom: 1px solid var(--color-border-strong);
+  white-space: nowrap;
+  background: var(--color-surface-2);
+}
+
+.catch-table td {
+  padding: 0.85rem 1.25rem;
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.catch-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.catch-table tbody tr:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.catch-table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.catch-table tbody tr:hover {
+  background: rgba(201, 168, 76, 0.04);
+}
+
+.catch-weight {
+  color: var(--color-gold);
+  font-weight: 400;
+}
+
+.catch-record-row td {
+  background: rgba(201, 168, 76, 0.05) !important;
+}
+
+.record-badge {
+  display: inline-block;
+  font-size: 0.62rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-bg);
+  background: var(--color-gold);
+  padding: 0.2rem 0.5rem;
+  border-radius: 2px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.catch-cards {
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.catch-card {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+}
+
+.catch-card--record {
+  border-color: var(--color-border-strong);
+  background: rgba(201, 168, 76, 0.04);
+}
+
+.catch-card-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.875rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.catch-card-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.catch-card-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+/* === RIVER CONDITIONS WIDGET === */
+.conditions-card {
+  max-width: 1280px;
+  margin: 0 auto var(--space-lg);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius);
+  padding: 1.75rem 2rem;
+}
+
+.conditions-title {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  color: var(--color-text);
+  margin-bottom: 1.25rem;
+}
+
+.conditions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.conditions-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.conditions-value-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.2rem;
+}
+
+.conditions-value-text {
+  font-family: var(--font-display);
+  font-size: 2.2rem;
+  color: var(--color-text);
+  line-height: 1;
+}
+
+.conditions-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.conditions-tag {
+  font-family: var(--font-body);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 2px;
+}
+
+.conditions-tag--normal {
+  color: #4caf7d;
+  background: rgba(76, 175, 125, 0.12);
+  border: 1px solid rgba(76, 175, 125, 0.3);
+}
+
+.conditions-dots {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(240, 236, 227, 0.18);
+  flex-shrink: 0;
+}
+
+.dot--filled {
+  background: var(--color-gold);
+}
+
+.conditions-updated {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+  margin-top: 0;
+}
+
 /* === BOOKING PAGE === */
 .booking-page {
   padding: var(--space-lg) var(--space-md) var(--space-xl);

--- a/demo-premium-lodge/index.html
+++ b/demo-premium-lodge/index.html
@@ -233,6 +233,49 @@
     </section>
 
 
+    <!-- === SEASON CALENDAR SECTION === -->
+    <section id="season-calendar" class="season-calendar" aria-label="Sesongkalender">
+      <div class="season-calendar-inner">
+        <div class="section-header fade-in">
+          <span class="section-badge" data-i18n="calendar.badge">Sesongkalender</span>
+          <h2 data-i18n="calendar.heading">Planlegg sesongen din</h2>
+          <div class="divider-line"></div>
+        </div>
+        <div class="season-grid">
+
+          <div class="season-block season-block--early fade-in">
+            <h3 class="season-block-name" data-i18n="calendar.early.name">Tidligsesong</h3>
+            <p class="season-block-dates" data-i18n="calendar.early.dates">15.–31. mai</p>
+            <p class="season-block-price">750 <span data-i18n="calendar.perrod">kr/stang/dag</span></p>
+            <p class="season-block-tip" data-i18n="calendar.early.tip">Første laksen, rolige elver</p>
+          </div>
+
+          <div class="season-block season-block--peak fade-in fade-in-delay-1">
+            <h3 class="season-block-name" data-i18n="calendar.peak.name">Høysesong</h3>
+            <p class="season-block-dates" data-i18n="calendar.peak.dates">1. jun – 15. jul</p>
+            <p class="season-block-price">950 <span data-i18n="calendar.perrod">kr/stang/dag</span></p>
+            <p class="season-block-tip" data-i18n="calendar.peak.tip">Beste fiske, størst etterspørsel</p>
+          </div>
+
+          <div class="season-block season-block--mid fade-in fade-in-delay-2">
+            <h3 class="season-block-name" data-i18n="calendar.mid.name">Midsesong</h3>
+            <p class="season-block-dates" data-i18n="calendar.mid.dates">16. jul – 31. aug</p>
+            <p class="season-block-price">850 <span data-i18n="calendar.perrod">kr/stang/dag</span></p>
+            <p class="season-block-tip" data-i18n="calendar.mid.tip">Stabil fangst, varmt vær</p>
+          </div>
+
+          <div class="season-block season-block--late fade-in fade-in-delay-3">
+            <h3 class="season-block-name" data-i18n="calendar.late.name">Sluttsesong</h3>
+            <p class="season-block-dates" data-i18n="calendar.late.dates">1.–15. sep</p>
+            <p class="season-block-price">650 <span data-i18n="calendar.perrod">kr/stang/dag</span></p>
+            <p class="season-block-tip" data-i18n="calendar.late.tip">Store hunnlaks, lave priser</p>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+
     <!-- === BOOKING SECTION === -->
     <section id="booking" class="booking" aria-label="Booking">
       <div class="booking-inner">
@@ -241,6 +284,8 @@
           <h2 data-i18n="booking.heading">Book ditt opphold</h2>
           <div class="divider-line"></div>
         </div>
+
+        <div id="offseason-notice" class="offseason-notice" role="alert" aria-live="polite"></div>
 
         <div class="booking-panel fade-in">
 
@@ -263,10 +308,12 @@
               <div class="booking-form-group">
                 <label for="booking-arrival" data-i18n="booking.arrival.label">Ankomst</label>
                 <input type="date" id="booking-arrival" class="booking-date" aria-label="Ankomstdato" />
+                <p class="date-error" id="arrival-error" aria-live="polite"></p>
               </div>
               <div class="booking-form-group">
                 <label for="booking-departure" data-i18n="booking.departure.label">Avreise</label>
                 <input type="date" id="booking-departure" class="booking-date" aria-label="Avreisedato" />
+                <p class="date-error" id="departure-error" aria-live="polite"></p>
               </div>
             </div>
 
@@ -476,8 +523,167 @@
     </section>
 
 
+    <!-- === CATCH REPORT SECTION === -->
+    <section id="catch-report" class="catch-report" aria-label="Fangstrapport">
+      <div class="catch-report-inner">
+        <div class="section-header fade-in">
+          <span class="section-badge" data-i18n="catch.badge">Fangstrapport</span>
+          <h2 data-i18n="catch.heading">Siste fangster fra Orkla</h2>
+          <div class="divider-line"></div>
+        </div>
+
+        <!-- Desktop table -->
+        <div class="catch-table-wrap fade-in">
+          <table class="catch-table">
+            <thead>
+              <tr>
+                <th scope="col" data-i18n="catch.col.date">Dato</th>
+                <th scope="col" data-i18n="catch.col.beat">Beat</th>
+                <th scope="col" data-i18n="catch.col.weight">Vekt</th>
+                <th scope="col" data-i18n="catch.col.method">Metode</th>
+                <th scope="col" data-i18n="catch.col.angler">Fisker</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>28. aug 2025</td>
+                <td>Øvre Elv</td>
+                <td class="catch-weight">8,2 kg</td>
+                <td>Flue</td>
+                <td>Thomas B.</td>
+              </tr>
+              <tr>
+                <td>25. aug 2025</td>
+                <td>Nedre Poll</td>
+                <td class="catch-weight">5,7 kg</td>
+                <td>Sluk</td>
+                <td>Kari M.</td>
+              </tr>
+              <tr class="catch-record-row">
+                <td>22. aug 2025</td>
+                <td>Midtre Stryk</td>
+                <td class="catch-weight">11,4 kg <span class="record-badge" data-i18n="catch.record.badge">Sesongrekord</span></td>
+                <td>Flue</td>
+                <td>Erik S.</td>
+              </tr>
+              <tr>
+                <td>18. aug 2025</td>
+                <td>Øvre Elv</td>
+                <td class="catch-weight">6,9 kg</td>
+                <td>Flue</td>
+                <td>Anders L.</td>
+              </tr>
+              <tr>
+                <td>15. aug 2025</td>
+                <td>Nedre Poll</td>
+                <td class="catch-weight">4,3 kg</td>
+                <td>Sluk</td>
+                <td>Ingrid P.</td>
+              </tr>
+              <tr>
+                <td>12. aug 2025</td>
+                <td>Midtre Stryk</td>
+                <td class="catch-weight">9,1 kg</td>
+                <td>Flue</td>
+                <td>Hans O.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile cards -->
+        <div class="catch-cards">
+          <div class="catch-card fade-in">
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.date">Dato</span><span>28. aug 2025</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.beat">Beat</span><span>Øvre Elv</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.weight">Vekt</span><span class="catch-weight">8,2 kg</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.method">Metode</span><span>Flue</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.angler">Fisker</span><span>Thomas B.</span></div>
+          </div>
+          <div class="catch-card fade-in fade-in-delay-1">
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.date">Dato</span><span>25. aug 2025</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.beat">Beat</span><span>Nedre Poll</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.weight">Vekt</span><span class="catch-weight">5,7 kg</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.method">Metode</span><span>Sluk</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.angler">Fisker</span><span>Kari M.</span></div>
+          </div>
+          <div class="catch-card catch-card--record fade-in fade-in-delay-2">
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.date">Dato</span><span>22. aug 2025</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.beat">Beat</span><span>Midtre Stryk</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.weight">Vekt</span><span class="catch-weight">11,4 kg <span class="record-badge" data-i18n="catch.record.badge">Sesongrekord</span></span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.method">Metode</span><span>Flue</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.angler">Fisker</span><span>Erik S.</span></div>
+          </div>
+          <div class="catch-card fade-in">
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.date">Dato</span><span>18. aug 2025</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.beat">Beat</span><span>Øvre Elv</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.weight">Vekt</span><span class="catch-weight">6,9 kg</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.method">Metode</span><span>Flue</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.angler">Fisker</span><span>Anders L.</span></div>
+          </div>
+          <div class="catch-card fade-in fade-in-delay-1">
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.date">Dato</span><span>15. aug 2025</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.beat">Beat</span><span>Nedre Poll</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.weight">Vekt</span><span class="catch-weight">4,3 kg</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.method">Metode</span><span>Sluk</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.angler">Fisker</span><span>Ingrid P.</span></div>
+          </div>
+          <div class="catch-card fade-in fade-in-delay-2">
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.date">Dato</span><span>12. aug 2025</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.beat">Beat</span><span>Midtre Stryk</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.weight">Vekt</span><span class="catch-weight">9,1 kg</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.method">Metode</span><span>Flue</span></div>
+            <div class="catch-card-row"><span class="catch-card-label" data-i18n="catch.col.angler">Fisker</span><span>Hans O.</span></div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+
     <!-- === CONTACT SECTION === -->
     <section id="contact" class="contact" aria-label="Kontakt">
+
+      <!-- River conditions widget -->
+      <div class="conditions-card fade-in">
+        <h3 class="conditions-title" data-i18n="conditions.title">Elveforhold nå</h3>
+        <div class="conditions-grid">
+          <div class="conditions-item">
+            <div class="conditions-value-row">
+              <span class="conditions-value-text" data-i18n="conditions.watertemp.value">12°C</span>
+            </div>
+            <span class="conditions-label" data-i18n="conditions.watertemp.label">Vanntemperatur</span>
+          </div>
+          <div class="conditions-item">
+            <div class="conditions-value-row">
+              <span class="conditions-value-text" data-i18n="conditions.waterlevel.value">48 cm</span>
+              <span class="conditions-tag conditions-tag--normal" data-i18n="conditions.tag.normal">Normal</span>
+            </div>
+            <span class="conditions-label" data-i18n="conditions.waterlevel.label">Vannstand</span>
+          </div>
+          <div class="conditions-item">
+            <div class="conditions-value-row">
+              <span class="conditions-value-text" data-i18n="conditions.airtemp.value">16°C</span>
+            </div>
+            <span class="conditions-label" data-i18n="conditions.airtemp.label">Lufttemperatur</span>
+          </div>
+          <div class="conditions-item">
+            <div class="conditions-value-row">
+              <span class="conditions-value-text" data-i18n="conditions.rating.value">God</span>
+              <span class="conditions-dots" aria-hidden="true">
+                <span class="dot dot--filled"></span>
+                <span class="dot dot--filled"></span>
+                <span class="dot dot--filled"></span>
+                <span class="dot dot--filled"></span>
+                <span class="dot"></span>
+              </span>
+            </div>
+            <span class="conditions-label" data-i18n="conditions.rating.label">Forhold</span>
+          </div>
+        </div>
+        <p class="conditions-updated" data-i18n="conditions.updated">Sist oppdatert: i dag kl. 08:00</p>
+      </div>
+
       <div class="contact-inner">
         <div class="fade-in">
           <span class="section-badge" data-i18n="contact.badge">Finn oss</span>
@@ -537,6 +743,13 @@ Orkland, Trøndelag</span>
       <p class="modal-sub" data-i18n="modal.sub">Du vil motta en bekreftelse på e-post innen 24 timer.</p>
       <button class="modal-close" id="modal-close" data-i18n="modal.close">Lukk</button>
     </div>
+  </div>
+
+
+  <!-- === STICKY BOOKING BAR === -->
+  <div id="sticky-bar" class="sticky-bar" role="complementary" aria-label="Hurtigbooking" aria-hidden="true">
+    <span class="sticky-bar-text" data-i18n="sticky.text">Klar til å booke? Priser fra 650 kr/stang/dag</span>
+    <button type="button" class="sticky-bar-btn" id="sticky-bar-btn" data-i18n="sticky.cta">Book nå</button>
   </div>
 
 

--- a/demo-premium-lodge/js/app.js
+++ b/demo-premium-lodge/js/app.js
@@ -2,6 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   initLanguage();
   initNav();
+  initStickyBar();
   initScrollAnimations();
   initScrollTop();
   initBooking();

--- a/demo-premium-lodge/js/booking.js
+++ b/demo-premium-lodge/js/booking.js
@@ -1,3 +1,52 @@
+// === OFF-SEASON DETECTION ===
+function getSeasonStatus() {
+  const today = new Date();
+  const m = today.getMonth(); // 0-indexed
+  const d = today.getDate();
+  const before = m < 4 || (m === 4 && d < 15);
+  const after = (m === 8 && d > 15) || m > 8;
+  return { offSeason: before || after, before };
+}
+
+function getNextSeasonYear() {
+  const today = new Date();
+  const { before } = getSeasonStatus();
+  return before ? today.getFullYear() : today.getFullYear() + 1;
+}
+
+function updateOffseasonNotice() {
+  const notice = document.getElementById('offseason-notice');
+  if (!notice) return;
+  const { offSeason } = getSeasonStatus();
+  if (!offSeason) {
+    notice.classList.remove('visible');
+    return;
+  }
+  const year = getNextSeasonYear();
+  const t = translations[currentLang];
+  notice.textContent = t['booking.offseason.notice'].replace('{year}', year);
+  notice.classList.add('visible');
+}
+
+function validateDateInput(input, errorId) {
+  const errorEl = document.getElementById(errorId);
+  if (!errorEl || !input) return;
+  if (!input.value) {
+    errorEl.classList.remove('visible');
+    return;
+  }
+  const val = new Date(input.value + 'T12:00:00');
+  const yr = val.getFullYear();
+  const seasonStart = new Date(`${yr}-05-15T12:00:00`);
+  const seasonEnd = new Date(`${yr}-09-15T12:00:00`);
+  if (val < seasonStart || val > seasonEnd) {
+    errorEl.textContent = translations[currentLang]['booking.date.error'];
+    errorEl.classList.add('visible');
+  } else {
+    errorEl.classList.remove('visible');
+  }
+}
+
 // === BOOKING SYSTEM ===
 const BEATS = {
   'ovre-elv': { maxRods: 3 },
@@ -165,6 +214,26 @@ function initBooking() {
     departureInput.max = seasonMax;
   }
 
+  // Pre-fill arrival date and show notice when currently off-season
+  const { offSeason, before } = getSeasonStatus();
+  if (offSeason) {
+    const fillYear = before ? new Date().getFullYear() : new Date().getFullYear() + 1;
+    if (arrivalInput && !arrivalInput.value) {
+      arrivalInput.value = `${fillYear}-05-15`;
+      if (departureInput) departureInput.min = `${fillYear}-05-16`;
+    }
+  }
+  updateOffseasonNotice();
+
+  // Re-run notice + error text on language toggle
+  document.querySelectorAll('#lang-toggle, #lang-toggle-mobile').forEach(btn => {
+    if (btn) btn.addEventListener('click', () => {
+      updateOffseasonNotice();
+      if (arrivalInput && arrivalInput.value) validateDateInput(arrivalInput, 'arrival-error');
+      if (departureInput && departureInput.value) validateDateInput(departureInput, 'departure-error');
+    });
+  });
+
   let maxRods = 4;
   let currentRods = 1;
 
@@ -188,6 +257,7 @@ function initBooking() {
   // Arrival change
   if (arrivalInput) {
     arrivalInput.addEventListener('change', () => {
+      validateDateInput(arrivalInput, 'arrival-error');
       if (arrivalInput.value) {
         const nextDay = new Date(arrivalInput.value + 'T12:00:00');
         nextDay.setDate(nextDay.getDate() + 1);
@@ -203,7 +273,12 @@ function initBooking() {
     });
   }
 
-  if (departureInput) departureInput.addEventListener('change', updateBookingDisplay);
+  if (departureInput) {
+    departureInput.addEventListener('change', () => {
+      validateDateInput(departureInput, 'departure-error');
+      updateBookingDisplay();
+    });
+  }
 
   // Stepper
   if (rodsMinus) rodsMinus.addEventListener('click', () => {

--- a/demo-premium-lodge/js/nav.js
+++ b/demo-premium-lodge/js/nav.js
@@ -1,3 +1,46 @@
+// === STICKY BOOKING BAR ===
+function initStickyBar() {
+  const bar = document.getElementById('sticky-bar');
+  const btn = document.getElementById('sticky-bar-btn');
+  const bookingSection = document.getElementById('booking');
+  const scrollTopBtn = document.getElementById('scroll-top');
+
+  if (!bar || !bookingSection) return;
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        // Booking section is in view — hide bar
+        bar.classList.remove('visible');
+        bar.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('sticky-bar-visible');
+        if (scrollTopBtn) scrollTopBtn.style.bottom = '';
+      } else {
+        // Only show bar when booking section has scrolled above viewport
+        if (entry.boundingClientRect.top < 0) {
+          bar.classList.add('visible');
+          bar.setAttribute('aria-hidden', 'false');
+          document.body.classList.add('sticky-bar-visible');
+          if (scrollTopBtn) scrollTopBtn.style.bottom = '5rem';
+        } else {
+          bar.classList.remove('visible');
+          bar.setAttribute('aria-hidden', 'true');
+          document.body.classList.remove('sticky-bar-visible');
+          if (scrollTopBtn) scrollTopBtn.style.bottom = '';
+        }
+      }
+    });
+  }, { threshold: 0 });
+
+  observer.observe(bookingSection);
+
+  if (btn) {
+    btn.addEventListener('click', () => {
+      bookingSection.scrollIntoView({ behavior: 'smooth' });
+    });
+  }
+}
+
 // === NAVIGATION ===
 function initNav() {
   const nav = document.querySelector('.nav');

--- a/demo-premium-lodge/js/translations.js
+++ b/demo-premium-lodge/js/translations.js
@@ -155,6 +155,54 @@ const translations = {
     'stats.label2': 'Meter elvestrekk',
     'stats.label3': 'Laks fanget per sesong',
     'stats.label4': 'Maks stenger samtidig',
+
+    // Off-season notice and date validation
+    'booking.offseason.notice': 'Sesongen {year} åpner 15. mai — reserver din plass nå!',
+    'booking.date.error': 'Sesongen er 15. mai – 15. september',
+
+    // Catch report section
+    'catch.badge': 'Fangstrapport',
+    'catch.heading': 'Siste fangster fra Orkla',
+    'catch.col.date': 'Dato',
+    'catch.col.beat': 'Beat',
+    'catch.col.weight': 'Vekt',
+    'catch.col.method': 'Metode',
+    'catch.col.angler': 'Fisker',
+    'catch.record.badge': 'Sesongrekord',
+
+    // Sticky booking bar
+    'sticky.text': 'Klar til å booke? Priser fra 650 kr/stang/dag',
+    'sticky.cta': 'Book nå',
+
+    // River conditions widget
+    'conditions.title': 'Elveforhold nå',
+    'conditions.watertemp.label': 'Vanntemperatur',
+    'conditions.watertemp.value': '12°C',
+    'conditions.waterlevel.label': 'Vannstand',
+    'conditions.waterlevel.value': '48 cm',
+    'conditions.tag.normal': 'Normal',
+    'conditions.airtemp.label': 'Lufttemperatur',
+    'conditions.airtemp.value': '16°C',
+    'conditions.rating.label': 'Forhold',
+    'conditions.rating.value': 'God',
+    'conditions.updated': 'Sist oppdatert: i dag kl. 08:00',
+
+    // Season calendar section
+    'calendar.badge': 'Sesongkalender',
+    'calendar.heading': 'Planlegg sesongen din',
+    'calendar.early.name': 'Tidligsesong',
+    'calendar.early.dates': '15.–31. mai',
+    'calendar.early.tip': 'Første laksen, rolige elver',
+    'calendar.peak.name': 'Høysesong',
+    'calendar.peak.dates': '1. jun – 15. jul',
+    'calendar.peak.tip': 'Beste fiske, størst etterspørsel',
+    'calendar.mid.name': 'Midsesong',
+    'calendar.mid.dates': '16. jul – 31. aug',
+    'calendar.mid.tip': 'Stabil fangst, varmt vær',
+    'calendar.late.name': 'Sluttsesong',
+    'calendar.late.dates': '1.–15. sep',
+    'calendar.late.tip': 'Store hunnlaks, lave priser',
+    'calendar.perrod': 'kr/stang/dag',
   },
 
   en: {
@@ -312,5 +360,53 @@ const translations = {
     'stats.label2': 'Metres of river stretch',
     'stats.label3': 'Salmon caught per season',
     'stats.label4': 'Max rods at any time',
+
+    // Off-season notice and date validation
+    'booking.offseason.notice': 'The {year} season opens 15 May — reserve your spot now!',
+    'booking.date.error': 'Season runs 15 May – 15 September',
+
+    // Catch report section
+    'catch.badge': 'Catch Report',
+    'catch.heading': 'Recent catches from the Orkla',
+    'catch.col.date': 'Date',
+    'catch.col.beat': 'Beat',
+    'catch.col.weight': 'Weight',
+    'catch.col.method': 'Method',
+    'catch.col.angler': 'Angler',
+    'catch.record.badge': 'Season record',
+
+    // Sticky booking bar
+    'sticky.text': 'Ready to book? Prices from 650 NOK/rod/day',
+    'sticky.cta': 'Book now',
+
+    // River conditions widget
+    'conditions.title': 'River conditions now',
+    'conditions.watertemp.label': 'Water temp',
+    'conditions.watertemp.value': '12°C',
+    'conditions.waterlevel.label': 'Water level',
+    'conditions.waterlevel.value': '48 cm',
+    'conditions.tag.normal': 'Normal',
+    'conditions.airtemp.label': 'Air temp',
+    'conditions.airtemp.value': '16°C',
+    'conditions.rating.label': 'Conditions',
+    'conditions.rating.value': 'Good',
+    'conditions.updated': 'Last updated: today at 08:00',
+
+    // Season calendar section
+    'calendar.badge': 'Season calendar',
+    'calendar.heading': 'Plan your season',
+    'calendar.early.name': 'Early season',
+    'calendar.early.dates': '15–31 May',
+    'calendar.early.tip': 'First salmon, quiet rivers',
+    'calendar.peak.name': 'Peak season',
+    'calendar.peak.dates': '1 Jun – 15 Jul',
+    'calendar.peak.tip': 'Best fishing, highest demand',
+    'calendar.mid.name': 'Mid season',
+    'calendar.mid.dates': '16 Jul – 31 Aug',
+    'calendar.mid.tip': 'Steady catches, warm weather',
+    'calendar.late.name': 'Late season',
+    'calendar.late.dates': '1–15 Sep',
+    'calendar.late.tip': 'Large hen salmon, low prices',
+    'calendar.perrod': 'NOK/rod/day',
   }
 };


### PR DESCRIPTION
### Changes:

- Off-season date blocking — arrival/departure date pickers constrained to May 15–Sep 15; inline validation errors on out-of-range selection; off-season banner pre-fills May 15 and shows season-open message on both index.html and booking.html
- Fangstrapport section — table (desktop) / cards (mobile) showing 6 recent catches between Testimonials and Contact; Sesongrekord gold badge on the 11.4 kg row; weight column in gold
- Sticky booking bar — fixed bottom bar on index.html only; slides in via IntersectionObserver when booking section scrolls out of view; hides on scroll back; scroll-top button adjusts to avoid overlap
- Elveforhold nå widget — compact card at top of Contact section; 2×2 grid with water temp, water level (Normal badge), air temp, and rating (4 gold / 1 muted dots)
- Sesongkalender section — 4 colour-coded season blocks between Beats and Booking; stacks as vertical timeline on mobile
- All new text added to translations.js with full NO/EN support

### Testing notes:

- [ ] Currently April, so off-season banner should be visible on both booking pages showing "2026"
- [ ] Scroll past booking section on index.html to verify sticky bar appears/disappears
- [ ] Pick a date before May 15 or after Sep 15 in a date field — error message should appear below it
- [ ] Toggle language — all new sections switch correctly
- [ ] Verify mobile: table hides → catch cards show; season blocks stack vertically

close #7 